### PR TITLE
Fix/change custom field types

### DIFF
--- a/src/Order/CustomFields.php
+++ b/src/Order/CustomFields.php
@@ -2,8 +2,16 @@
 declare(strict_types = 1);
 namespace SnowIO\OrderHiveDataModel\Order;
 
+use SnowIO\OrderHiveDataModel\OrderHiveDataException;
+
 final class CustomFields
 {
+    const TYPE_TEXT = 'TEXT';
+    const TYPE_DROP_DOWN = 'DROP_DOWN';
+    const TYPE_DATE = 'DATE';
+    const TYPE_CHECKBOX = 'CHECKBOX';
+    const TYPE_NUMBER = 'NUMBER';
+
     public static function of($name, $type, $value): self
     {
         return (new self($name, $type, $value));
@@ -40,8 +48,23 @@ final class CustomFields
     private $type;
     private $value;
 
+    private function validateType(string $type): bool
+    {
+        return in_array($type, [
+            self::TYPE_TEXT,
+            self::TYPE_CHECKBOX,
+            self::TYPE_DATE,
+            self::TYPE_DROP_DOWN,
+            self::TYPE_NUMBER
+        ]);
+    }
+
     private function __construct($name, $type, $value)
     {
+        if (!$this->validateType($type)) {
+            throw new OrderHiveDataException($type . ' is not a valid custom field type');
+        }
+
         $this->name = $name;
         $this->type = $type;
         $this->value = $value;

--- a/tests/Unit/Command/CreateOrderCommandTest.php
+++ b/tests/Unit/Command/CreateOrderCommandTest.php
@@ -25,7 +25,7 @@ class CreateOrderCommandTest extends TestCase
             'channel_order_number' => 'test',
             'tax_type' => "EXCLUSIVE",
             'custom_fields' => [
-                ["name" => "PO Reference", "type" => "STRING", "value" => "123"]
+                ["name" => "PO Reference", "type" => "TEXT", "value" => "123"]
             ],
             'currency' => "USD",
         ]);
@@ -36,7 +36,7 @@ class CreateOrderCommandTest extends TestCase
             ->withStoreId(46670)
             ->withCurrency("USD")
             ->withTaxType("EXCLUSIVE")
-            ->withCustomFields(CustomFieldsSet::of([CustomFields::of('PO Reference', 'STRING', '123')]));
+            ->withCustomFields(CustomFieldsSet::of([CustomFields::of('PO Reference', 'TEXT', '123')]));
 
         self::assertEquals($expected, $createOrderCommand->getCreateOrder());
     }
@@ -47,7 +47,7 @@ class CreateOrderCommandTest extends TestCase
             ->withOrderStatus(OrderStatus::CONFIRM)
             ->withCurrency('USD')
             ->withStoreId(13)
-            ->withCustomFields(CustomFieldsSet::of([CustomFields::of('PO Reference', 'STRING', '123')]));
+            ->withCustomFields(CustomFieldsSet::of([CustomFields::of('PO Reference', 'TEXT', '123')]));
 
         $createOrderCommand = CreateOrderCommand::of($order);
 
@@ -72,7 +72,7 @@ class CreateOrderCommandTest extends TestCase
             'custom_fields' => [
                 [
                     "name" => "PO Reference",
-                    "type" => "STRING",
+                    "type" => "TEXT",
                     "value" => "123",
                 ]
             ],

--- a/tests/Unit/Command/CreateOrderCommandTest.php
+++ b/tests/Unit/Command/CreateOrderCommandTest.php
@@ -7,11 +7,7 @@ use SnowIO\OrderHiveDataModel\Command\CreateOrderCommand;
 use SnowIO\OrderHiveDataModel\Order\CreateOrder;
 use SnowIO\OrderHiveDataModel\Order\CustomFields;
 use SnowIO\OrderHiveDataModel\Order\CustomFieldsSet;
-use SnowIO\OrderHiveDataModel\Order\Order;
 use SnowIO\OrderHiveDataModel\Order\OrderStatus;
-use SnowIO\OrderHiveDataModel\Order\TaxInfo;
-use SnowIO\OrderHiveDataModel\Order\TaxInfoGroup;
-use SnowIO\OrderHiveDataModel\Order\TaxInfoGroupSet;
 
 class CreateOrderCommandTest extends TestCase
 {
@@ -36,7 +32,7 @@ class CreateOrderCommandTest extends TestCase
             ->withStoreId(46670)
             ->withCurrency("USD")
             ->withTaxType("EXCLUSIVE")
-            ->withCustomFields(CustomFieldsSet::of([CustomFields::of('PO Reference', 'TEXT', '123')]));
+            ->withCustomFields(CustomFieldsSet::of([CustomFields::of('PO Reference', CustomFields::TYPE_TEXT, '123')]));
 
         self::assertEquals($expected, $createOrderCommand->getCreateOrder());
     }
@@ -47,7 +43,7 @@ class CreateOrderCommandTest extends TestCase
             ->withOrderStatus(OrderStatus::CONFIRM)
             ->withCurrency('USD')
             ->withStoreId(13)
-            ->withCustomFields(CustomFieldsSet::of([CustomFields::of('PO Reference', 'TEXT', '123')]));
+            ->withCustomFields(CustomFieldsSet::of([CustomFields::of('PO Reference', CustomFields::TYPE_TEXT, '123')]));
 
         $createOrderCommand = CreateOrderCommand::of($order);
 
@@ -72,7 +68,7 @@ class CreateOrderCommandTest extends TestCase
             'custom_fields' => [
                 [
                     "name" => "PO Reference",
-                    "type" => "TEXT",
+                    "type" => CustomFields::TYPE_TEXT,
                     "value" => "123",
                 ]
             ],

--- a/tests/Unit/Order/CustomFieldsSetTest.php
+++ b/tests/Unit/Order/CustomFieldsSetTest.php
@@ -12,7 +12,7 @@ class CustomFieldsTest extends TestCase
     public function testCustomFieldsSetToJson()
     {
         $customFieldSet = CustomFieldsSet::of([
-            CustomFields::of('field name', 'NUMBER', '123')
+            CustomFields::of('field name', CustomFields::TYPE_NUMBER, '123')
         ]);
 
         self::assertEquals([
@@ -25,8 +25,8 @@ class CustomFieldsTest extends TestCase
         $this->expectException(OrderHiveDataException::class);
 
         CustomFieldsSet::of([
-            CustomFields::of('a', 'TEXT', '123'),
-            CustomFields::of('a', 'TEXT', '123')
+            CustomFields::of('a', CustomFields::TYPE_TEXT, '123'),
+            CustomFields::of('a', CustomFields::TYPE_TEXT, '123')
         ]);
     }
 
@@ -44,8 +44,8 @@ class CustomFieldsTest extends TestCase
         $this->expectException(OrderHiveDataException::class);
 
         CustomFieldsSet::fromJson([
-            CustomFields::of('a', 'TEXT', '123')->toJson(),
-            CustomFields::of('a', 'TEXT', '123')->toJson(),
+            CustomFields::of('a', CustomFields::TYPE_TEXT, '123')->toJson(),
+            CustomFields::of('a', CustomFields::TYPE_TEXT, '123')->toJson(),
         ]);
     }
 
@@ -64,13 +64,13 @@ class CustomFieldsTest extends TestCase
     public function testDefaultValues()
     {
         $customFieldSet = CustomFieldsSet::of([
-            CustomFields::of('a', 'TEXT', '123')
+            CustomFields::of('a', CustomFields::TYPE_TEXT, '123')
         ]);
 
         self::assertEquals([
             [
                 'name' => 'a',
-                'type' => 'TEXT',
+                'type' => CustomFields::TYPE_TEXT,
                 'value' => '123'
             ]
         ], $customFieldSet->toJson());
@@ -81,15 +81,15 @@ class CustomFieldsTest extends TestCase
         $this->expectException(OrderHiveDataException::class);
 
         CustomFieldsSet::of([
-            CustomFields::of('a', 'TEXT', '123'),
-            CustomFields::of('a', 'TEXT', '123')
+            CustomFields::of('a', CustomFields::TYPE_TEXT, '123'),
+            CustomFields::of('a', CustomFields::TYPE_TEXT, '123')
         ]);
     }
 
     public function testGetShouldUseOrderItemIdAsKey()
     {
         $customFieldSet = CustomFieldsSet::of([
-            CustomFields::of('a', 'TEXT', '123')
+            CustomFields::of('a', CustomFields::TYPE_TEXT, '123')
         ]);
         self::assertInstanceOf(CustomFields::class, $customFieldSet->get('a'));
         self::assertNull($customFieldSet->get('b'));
@@ -98,19 +98,19 @@ class CustomFieldsTest extends TestCase
     public function testEquality()
     {
         $customFieldSet = CustomFieldsSet::of([
-            CustomFields::of('a', 'TEXT', '123'),
-            CustomFields::of('b', 'TEXT', '123'),
-            CustomFields::of('c', 'TEXT', '123'),
+            CustomFields::of('a', CustomFields::TYPE_TEXT, '123'),
+            CustomFields::of('b', CustomFields::TYPE_TEXT, '123'),
+            CustomFields::of('c', CustomFields::TYPE_TEXT, '123'),
         ]);
         $sameSet = CustomFieldsSet::of([
-            CustomFields::of('a', 'TEXT', '123'),
-            CustomFields::of('b', 'TEXT', '123'),
-            CustomFields::of('c', 'TEXT', '123'),
+            CustomFields::of('a', CustomFields::TYPE_TEXT, '123'),
+            CustomFields::of('b', CustomFields::TYPE_TEXT, '123'),
+            CustomFields::of('c', CustomFields::TYPE_TEXT, '123'),
         ]);
         $notSameSet = CustomFieldsSet::of([
-            CustomFields::of('a', 'TEXT', '111'),
-            CustomFields::of('b', 'TEXT', '222'),
-            CustomFields::of('c', 'TEXT', '333'),
+            CustomFields::of('a', CustomFields::TYPE_TEXT, '111'),
+            CustomFields::of('b', CustomFields::TYPE_TEXT, '222'),
+            CustomFields::of('c', CustomFields::TYPE_TEXT, '333'),
         ]);
 
         self::assertTrue($customFieldSet->equals($sameSet));
@@ -121,7 +121,7 @@ class CustomFieldsTest extends TestCase
     {
         return [
             'name' => $name,
-            'type' => 'NUMBER',
+            'type' => CustomFields::TYPE_NUMBER,
             'value' => '123'
         ];
     }

--- a/tests/Unit/Order/CustomFieldsSetTest.php
+++ b/tests/Unit/Order/CustomFieldsSetTest.php
@@ -25,8 +25,17 @@ class CustomFieldsTest extends TestCase
         $this->expectException(OrderHiveDataException::class);
 
         CustomFieldsSet::of([
-            CustomFields::of('a', 'STRING', '123'),
-            CustomFields::of('a', 'STRING', '123')
+            CustomFields::of('a', 'TEXT', '123'),
+            CustomFields::of('a', 'TEXT', '123')
+        ]);
+    }
+
+    public function testInvalidCustomFieldType()
+    {
+        $this->expectException(OrderHiveDataException::class);
+
+        CustomFieldsSet::of([
+            CustomFields::of('a', 'INVALID', '123')
         ]);
     }
 
@@ -35,8 +44,8 @@ class CustomFieldsTest extends TestCase
         $this->expectException(OrderHiveDataException::class);
 
         CustomFieldsSet::fromJson([
-            CustomFields::of('a', 'STRING', '123')->toJson(),
-            CustomFields::of('a', 'STRING', '123')->toJson(),
+            CustomFields::of('a', 'TEXT', '123')->toJson(),
+            CustomFields::of('a', 'TEXT', '123')->toJson(),
         ]);
     }
 
@@ -55,13 +64,13 @@ class CustomFieldsTest extends TestCase
     public function testDefaultValues()
     {
         $customFieldSet = CustomFieldsSet::of([
-            CustomFields::of('a', 'STRING', '123')
+            CustomFields::of('a', 'TEXT', '123')
         ]);
 
         self::assertEquals([
             [
                 'name' => 'a',
-                'type' => 'STRING',
+                'type' => 'TEXT',
                 'value' => '123'
             ]
         ], $customFieldSet->toJson());
@@ -72,15 +81,15 @@ class CustomFieldsTest extends TestCase
         $this->expectException(OrderHiveDataException::class);
 
         CustomFieldsSet::of([
-            CustomFields::of('a', 'STRING', '123'),
-            CustomFields::of('a', 'STRING', '123')
+            CustomFields::of('a', 'TEXT', '123'),
+            CustomFields::of('a', 'TEXT', '123')
         ]);
     }
 
     public function testGetShouldUseOrderItemIdAsKey()
     {
         $customFieldSet = CustomFieldsSet::of([
-            CustomFields::of('a', 'STRING', '123')
+            CustomFields::of('a', 'TEXT', '123')
         ]);
         self::assertInstanceOf(CustomFields::class, $customFieldSet->get('a'));
         self::assertNull($customFieldSet->get('b'));
@@ -89,19 +98,19 @@ class CustomFieldsTest extends TestCase
     public function testEquality()
     {
         $customFieldSet = CustomFieldsSet::of([
-            CustomFields::of('a', 'STRING', '123'),
-            CustomFields::of('b', 'STRING', '123'),
-            CustomFields::of('c', 'STRING', '123'),
+            CustomFields::of('a', 'TEXT', '123'),
+            CustomFields::of('b', 'TEXT', '123'),
+            CustomFields::of('c', 'TEXT', '123'),
         ]);
         $sameSet = CustomFieldsSet::of([
-            CustomFields::of('a', 'STRING', '123'),
-            CustomFields::of('b', 'STRING', '123'),
-            CustomFields::of('c', 'STRING', '123'),
+            CustomFields::of('a', 'TEXT', '123'),
+            CustomFields::of('b', 'TEXT', '123'),
+            CustomFields::of('c', 'TEXT', '123'),
         ]);
         $notSameSet = CustomFieldsSet::of([
-            CustomFields::of('a', 'STRING', '111'),
-            CustomFields::of('b', 'STRING', '222'),
-            CustomFields::of('c', 'STRING', '333'),
+            CustomFields::of('a', 'TEXT', '111'),
+            CustomFields::of('b', 'TEXT', '222'),
+            CustomFields::of('c', 'TEXT', '333'),
         ]);
 
         self::assertTrue($customFieldSet->equals($sameSet));

--- a/tests/Unit/Order/OrderDetailsTest.php
+++ b/tests/Unit/Order/OrderDetailsTest.php
@@ -209,7 +209,7 @@ class OrderDetailsTest extends TestCase
             ->withContactId(52308715)
             ->withCurrency('USD')
             ->withCustomFields(CustomFieldsSet::of([
-                CustomFields::of('PO', 'TEXT', '123')
+                CustomFields::of('PO', CustomFields::TYPE_TEXT, '123')
             ]))
             ->withOrderItems(ItemSet::of([
                 Item::of(123, 1)

--- a/tests/Unit/Order/OrderDetailsTest.php
+++ b/tests/Unit/Order/OrderDetailsTest.php
@@ -158,7 +158,7 @@ class OrderDetailsTest extends TestCase
             "preset_id" => null,
             "fulfillment_status" => null,
             "custom_fields" => [
-                ["name" => "PO", "type" => "STRING", "value" => "123"]
+                ["name" => "PO", "type" => "TEXT", "value" => "123"]
             ],
             "unread_comment_count" => 0,
             "custom_pricing_tier_id" => null,
@@ -209,7 +209,7 @@ class OrderDetailsTest extends TestCase
             ->withContactId(52308715)
             ->withCurrency('USD')
             ->withCustomFields(CustomFieldsSet::of([
-                CustomFields::of('PO', 'STRING', '123')
+                CustomFields::of('PO', 'TEXT', '123')
             ]))
             ->withOrderItems(ItemSet::of([
                 Item::of(123, 1)


### PR DESCRIPTION
It seems the type STRING was replaced by TEXT so we start using constant and add validation to it.

<img width="749" alt="Screenshot 2020-05-15 at 20 34 34" src="https://user-images.githubusercontent.com/33385/82103995-90db6600-96eb-11ea-8955-8a98975fe932.png">
