### PR TITLE
Add method toJson which allow filter array by keys

### DIFF
--- a/src/Command/UpdateOrderCommand.php
+++ b/src/Command/UpdateOrderCommand.php
@@ -30,6 +30,20 @@ final class UpdateOrderCommand
         return $this->editOrder->toJson();
     }
 
+    /**
+     * Only return the specified keys which allow us to field specific
+     * updates and not empty other data
+     * @param $keys
+     * @return array
+     */
+    public function toJsonFiltered($keys): array
+    {
+        $json = $this->editOrder->toJson();
+        return array_filter($json, function ($key, $val) use ($keys){
+            return in_array($val, $keys) ? [$key => $val] : null;
+        }, ARRAY_FILTER_USE_BOTH);
+    }
+
     /** @var EditOrder */
     private $editOrder;
 

--- a/tests/Unit/Command/UpdateOrderCommandTest.php
+++ b/tests/Unit/Command/UpdateOrderCommandTest.php
@@ -86,4 +86,18 @@ class UpdateOrderCommandTest extends TestCase
             'order_items' => [],
         ], $updateOrderCommand->toJson());
     }
+
+    public function testToJsonFiltered()
+    {
+        $payload = UpdateOrderCommand::of(
+            EditOrder::of(127939562)
+                ->withDeliveryDate('2021-07-06 00:00:00')
+        )->toJsonFiltered(['id', 'delivery_date']);
+
+        self::assertEquals([
+            'id' => 127939562,
+            'delivery_date' => '2021-07-06 00:00:00',
+        ], $payload);
+    }
+
 }


### PR DESCRIPTION
The orderhive endpoint updates all the values specified on the payload, when it is null it will delete the information. So, we need to be able to only specify the field that we actually want to update.