### PR TITLE
Fix logic to filter keys when exporting array

### DIFF
--- a/src/Command/UpdateOrderCommand.php
+++ b/src/Command/UpdateOrderCommand.php
@@ -39,8 +39,8 @@ final class UpdateOrderCommand
     public function toJsonFiltered($keys): array
     {
         $json = $this->editOrder->toJson();
-        return array_filter($json, function ($key, $val) use ($keys){
-            return in_array($val, $keys) ? [$key => $val] : null;
+        return array_filter($json, function ($value, $key) use ($keys){
+            return in_array($key, $keys) ? [$key => $value] : null;
         }, ARRAY_FILTER_USE_BOTH);
     }
 

--- a/tests/Unit/Command/UpdateOrderCommandTest.php
+++ b/tests/Unit/Command/UpdateOrderCommandTest.php
@@ -92,11 +92,27 @@ class UpdateOrderCommandTest extends TestCase
         $payload = UpdateOrderCommand::of(
             EditOrder::of(127939562)
                 ->withDeliveryDate('2021-07-06 00:00:00')
-        )->toJsonFiltered(['id', 'delivery_date']);
+        )->toJsonFiltered(['id', 'delivery_date', 'shipping_address']);
 
         self::assertEquals([
             'id' => 127939562,
             'delivery_date' => '2021-07-06 00:00:00',
+            'shipping_address' => [
+                "address1" => null,
+                "address2" => null,
+                "city" => null,
+                "company" => null,
+                "contact_number" => null,
+                "country" => null,
+                "country_code" => null,
+                "created" => null,
+                "email" => null,
+                "id" => null,
+                "modified" => null,
+                "name" => null,
+                "state" => null,
+                "zipcode" => null,
+            ]
         ], $payload);
     }
 


### PR DESCRIPTION
The key/value parameter ordering was wrong and it was breaking when filtering a key where its value was an array.